### PR TITLE
fix default value

### DIFF
--- a/lib/tty/shell/question.rb
+++ b/lib/tty/shell/question.rb
@@ -287,7 +287,7 @@ module TTY
       #
       # @api private
       def evaluate_response(value)
-        return default_value if !value && default?
+        return default_value if (!value || value.empty?) && default?
         check_required(value)
         return if value.nil?
 

--- a/lib/tty/shell/reader.rb
+++ b/lib/tty/shell/reader.rb
@@ -72,7 +72,7 @@ module TTY
       #
       # @api public
       def gets
-        shell.input.gets
+        shell.input.gets.chomp
       end
 
       # Reads at maximum +maxlen+ characters.

--- a/spec/tty/shell/response/read_spec.rb
+++ b/spec/tty/shell/response/read_spec.rb
@@ -25,6 +25,24 @@ describe TTY::Shell::Question, '#read_password' do
       expect(output.string).to eql('What is your password: ')
       expect(q.mask?).to eq(false)
     end
+
+    context 'in raw mode' do
+      it 'returns the default' do
+        input << "\n"
+        input.rewind
+        q = shell.ask("What is your password: ").raw(true).default('test')
+        expect(q.read).to eql("test")
+      end
+    end
+
+    context 'not in raw mode' do
+      it 'returns the default' do
+        input << "\n"
+        input.rewind
+        q = shell.ask("What is your password: ").raw(false).default('test')
+        expect(q.read).to eql("test")
+      end
+    end
   end
 
   context 'with mask' do


### PR DESCRIPTION
When not in character mode, all shell input ends with a newline, which
among other things breaks the handling of default values in
Question#evaluate_response.

This commit removes the newline and changes Question#evaluate_response
to interpret an empty string as no entry.