### PR TITLE
shell: fix handling of default values

### DIFF
--- a/lib/tty/shell/response.rb
+++ b/lib/tty/shell/response.rb
@@ -68,6 +68,19 @@ module TTY
         end
       end
 
+      # @api private
+      def evaluate_response
+        input = read_input
+        input =
+          if !input || input == "\n" || input.empty?
+            nil
+          elsif block_given?
+            yield(input)
+          else input
+          end
+        question.evaluate_response(input)
+      end
+
       # Read answer and cast to String type
       #
       # @param [String] error
@@ -75,7 +88,7 @@ module TTY
       #
       # @api public
       def read_string(error = nil)
-        question.evaluate_response(String(read_input).strip)
+        evaluate_response { |input| String(input).strip }
       end
 
       # Read answer's first character
@@ -83,21 +96,21 @@ module TTY
       # @api public
       def read_char
         question.char(true)
-        question.evaluate_response String(read_input).chars.to_a[0]
+        evaluate_response { |input| String(input).chars.to_a[0] }
       end
 
       # Read multiple line answer and cast to String type
       #
       # @api public
       def read_text
-        question.evaluate_response String(read_input)
+        evaluate_response { |input| String(input) }
       end
 
       # Read ansewr and cast to Symbol type
       #
       # @api public
       def read_symbol(error = nil)
-        question.evaluate_response(read_input.to_sym)
+        evaluate_response { |input| input.to_sym }
       end
 
       # Read answer from predifined choicse
@@ -105,69 +118,63 @@ module TTY
       # @api public
       def read_choice(type = nil)
         question.argument(:required) unless question.default?
-        question.evaluate_response read_input
+        evaluate_response
       end
 
       # Read integer value
       #
       # @api public
       def read_int(error = nil)
-        response = @converter.convert(read_input).to(:integer)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:integer) }
       end
 
       # Read float value
       #
       # @api public
       def read_float(error = nil)
-        response = @converter.convert(read_input).to(:float)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:float) }
       end
 
       # Read regular expression
       #
       # @api public
       def read_regex(error = nil)
-        question.evaluate_response Kernel.send(:Regex, read_input)
+        evaluate_response { |input| Kernel.send(:Regex, input) }
       end
 
       # Read range expression
       #
       # @api public
       def read_range
-        response = @converter.convert(read_input).to(:range, strict: true)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:range, strict: true) }
       end
 
       # Read date
       #
       # @api public
       def read_date
-        response = @converter.convert(read_input).to(:date)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:date) }
       end
 
       # Read datetime
       #
       # @api public
       def read_datetime
-        response = @converter.convert(read_input).to(:datetime)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:datetime) }
       end
 
       # Read boolean
       #
       # @api public
       def read_bool(error = nil)
-        response = @converter.convert(read_input).to(:boolean, strict: true)
-        question.evaluate_response(response)
+        evaluate_response { |input| @converter.convert(input).to(:boolean, strict: true) }
       end
 
       # Read file contents
       #
       # @api public
       def read_file(error = nil)
-        question.evaluate_response File.open(File.join(directory, read_input))
+        evaluate_response { |input| File.open(File.join(directory, input)) }
       end
 
       # Read string answer and validate against email regex
@@ -187,7 +194,7 @@ module TTY
       def read_multiple
         response = ''
         loop do
-          value = question.evaluate_response read_input
+          value = evaluate_response
           break if !value || value == ''
           next  if value !~ /\S/
           response << value
@@ -200,7 +207,7 @@ module TTY
       # @api public
       def read_password
         question.echo false
-        question.evaluate_response read_input
+        evaluate_response
       end
 
       # Read a single keypress

--- a/spec/tty/shell/response/read_bool_spec.rb
+++ b/spec/tty/shell/response/read_bool_spec.rb
@@ -14,6 +14,13 @@ describe TTY::Shell::Question, '#read_bool' do
     expect { q.read_bool }.to raise_error(Necromancer::ConversionTypeError)
   end
 
+  it "handles default values" do
+    input << "\n"
+    input.rewind
+    q = shell.ask("Do you read books?").default(true)
+    expect(q.read_bool).to eql(true)
+  end
+
   it 'reads negative boolean' do
     input << 'No'
     input.rewind

--- a/spec/tty/shell/response/read_email_spec.rb
+++ b/spec/tty/shell/response/read_email_spec.rb
@@ -12,7 +12,7 @@ describe TTY::Shell::Question, '#read_email' do
       input << ""
       input.rewind
       q = shell.ask("What is your email?")
-      expect { q.read_email }.to raise_error(TTY::InvalidArgument)
+      expect(q.read_email).to eql(nil)
     end
 
     it 'reads valid email' do


### PR DESCRIPTION
This fixes handling of 'empty input' by having Response detect an
empty line input and feed it to Question#evaluate_response. Another
code path I saw would have required to change all Necromancer
converters to handle this special case ... did not seem appealing.

However, the current Response class assumes that it is possible for
read_input to distinguish between "no value provided" and "empty
line as input". Since I did not see how it was possible, I removed
that capability which ended up changing functionality:
 - read_multiple cannot input empty lines (since an empty line is
   now interpreted as no input)
 - read_email accepts empty email (but returns nil), which incidentally
   fixes default value handling for emails. If an email must be provided
   by the user, then call argument(:required).